### PR TITLE
Removing the View Demo item and dead link in astra.json

### DIFF
--- a/astra.json
+++ b/astra.json
@@ -4,7 +4,6 @@
   "duration": "2 hours",
   "skillLevel": "Beginner",
   "githubUrl": "https://github.com/DataStax-Examples/astra-netflix",
-  "demoUrl": "https://sag-astra-netflix.netlify.app",
   "gitpodUrl": "https://gitpod.io/#https://github.com/DataStax-Examples/astra-netflix",
   "tags": [{ "name": "javascript" }, { "name": "GraphQL" }],
   "category": "apps",


### PR DESCRIPTION
The Netflix sample application is no longer available in netlify. If someone clicks the View Demo link in Astra, the user gets a 404. This PR removes the link to the netlify app. 